### PR TITLE
Create personal_access_tokens table with indexes

### DIFF
--- a/us3.sql
+++ b/us3.sql
@@ -2337,7 +2337,7 @@ ENGINE = InnoDB;
 -- Table personal_access_tokens
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS personal_access_tokens;
-create table personal_access_tokens
+CREATE TABLE IF NOT EXISTS personal_access_tokens
 (
     id             bigint unsigned auto_increment
         primary key,
@@ -2354,11 +2354,11 @@ create table personal_access_tokens
         unique (token)
 )
   ENGINE = InnoDB;
-DROP INDEX personal_access_tokens_expires_at_index ON personal_access_tokens;
-create index personal_access_tokens_expires_at_index
+DROP INDEX IF EXISTS personal_access_tokens_expires_at_index ON personal_access_tokens;
+CREATE INDEX IF NOT EXISTS personal_access_tokens_expires_at_index
     on personal_access_tokens (expires_at);
-DROP INDEX personal_access_tokens_tokenable_type_tokenable_id_index ON personal_access_tokens;
-create index personal_access_tokens_tokenable_type_tokenable_id_index
+DROP INDEX IF EXISTS personal_access_tokens_tokenable_type_tokenable_id_index ON personal_access_tokens;
+CREATE INDEX IF NOT EXISTS personal_access_tokens_tokenable_type_tokenable_id_index
     on personal_access_tokens (tokenable_type, tokenable_id);
 
 

--- a/us3.sql
+++ b/us3.sql
@@ -2333,6 +2333,37 @@ CREATE TABLE IF NOT EXISTS referenceScan (
 ENGINE = InnoDB;
 
 
+-- -----------------------------------------------------
+-- Table personal_access_tokens
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS personal_access_tokens;
+create table personal_access_tokens
+(
+    id             bigint unsigned auto_increment
+        primary key,
+    tokenable_type varchar(255)    not null,
+    tokenable_id   bigint unsigned not null,
+    name           text            not null,
+    token          varchar(64)     not null,
+    abilities      text            null,
+    last_used_at   timestamp       null,
+    expires_at     timestamp       null,
+    created_at     timestamp       null,
+    updated_at     timestamp       null,
+    constraint personal_access_tokens_token_unique
+        unique (token)
+)
+  ENGINE = InnoDB;
+DROP INDEX personal_access_tokens_expires_at_index ON personal_access_tokens;
+create index personal_access_tokens_expires_at_index
+    on personal_access_tokens (expires_at);
+DROP INDEX personal_access_tokens_tokenable_type_tokenable_id_index ON personal_access_tokens;
+create index personal_access_tokens_tokenable_type_tokenable_id_index
+    on personal_access_tokens (tokenable_type, tokenable_id);
+
+
+
+
 -- Load some non-changing hardware data
 SOURCE us3_hardware_data.sql
 SOURCE us3_buffer_components.sql


### PR DESCRIPTION
This pull request introduces a new `personal_access_tokens` table to the database schema, supporting the storage and management of personal access tokens. The table includes fields for token metadata, relationships, and indexing to optimize queries.

**Database schema changes:**

* Added a new `personal_access_tokens` table with columns for `id`, `tokenable_type`, `tokenable_id`, `name`, `token`, `abilities`, `last_used_at`, `expires_at`, `created_at`, and `updated_at`. Ensured the `token` field is unique.
* Created indexes on `expires_at` and the combination of `tokenable_type` and `tokenable_id` to improve query performance.