### PR TITLE
Enable account feature

### DIFF
--- a/us3.sql
+++ b/us3.sql
@@ -31,6 +31,7 @@ CREATE  TABLE IF NOT EXISTS people (
   username VARCHAR(80) NULL,
   password VARCHAR(80) NOT NULL ,
   activated TINYINT(1) NOT NULL DEFAULT false ,
+  account_enabled TINYINT(1) UNSIGNED NOT NULL DEFAULT 1 ,
   signup TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ,
   lastLogin DATETIME NULL ,
   clusterAuthorizations VARCHAR(255) NOT NULL default 'lonestar5:stampede2:comet:jetstream',
@@ -41,6 +42,40 @@ CREATE  TABLE IF NOT EXISTS people (
   userNamePAM VARCHAR(63) UNIQUE NOT NULL,
   PRIMARY KEY (personID) )
 ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table people_audit
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS people_audit ;
+
+CREATE TABLE IF NOT EXISTS people_audit (
+  auditID            INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  personID           INT NOT NULL,
+  user_email         VARCHAR(128) NULL,
+  user_name          VARCHAR(255) NULL,
+  changed_by_personID INT NULL,
+  changed_by_email   VARCHAR(128) NULL,
+  changed_by_name    VARCHAR(255) NULL,
+  action             ENUM(
+                         'CREATE',
+                         'UPDATE',
+                         'DELETE',
+                         'ACCOUNT_ENABLE',
+                         'ACCOUNT_DISABLE',
+                         'USERLEVEL_CHANGE',
+                         'ESCALATION_REJECTED'
+                     ) NOT NULL,
+  old_values         LONGTEXT NULL,
+  new_values         LONGTEXT NULL,
+  created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  notes              VARCHAR(255) NULL,
+  PRIMARY KEY (auditID),
+  INDEX idx_people_audit_person_time    (personID, created_at),
+  INDEX idx_people_audit_changedby_time (changed_by_personID, created_at),
+  INDEX idx_people_audit_action_time    (action, created_at),
+  INDEX idx_people_audit_created_at     (created_at)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 
 -- -----------------------------------------------------

--- a/us3_procedures.sql
+++ b/us3_procedures.sql
@@ -161,19 +161,20 @@ BEGIN
 END$$
 
 
-
 -- Checks the user with the passed GUID and password
+-- account_enabled = 0 blocks login even if activated = 1
 DROP FUNCTION IF EXISTS check_user$$
-CREATE FUNCTION check_user( p_personGUID     CHAR(36),
-                            p_password VARCHAR(80) )
+CREATE FUNCTION check_user( p_personGUID CHAR(36),
+                            p_password   VARCHAR(80) )
   RETURNS INT
   READS SQL DATA
 
 BEGIN
-  DECLARE count_user INT;
-  DECLARE md5_pw VARCHAR(80);
-  DECLARE l_password VARCHAR(80);
-  DECLARE activated INT;
+  DECLARE count_user        INT;
+  DECLARE md5_pw            VARCHAR(80);
+  DECLARE l_password        VARCHAR(80);
+  DECLARE l_activated       INT;
+  DECLARE l_account_enabled INT;
 
   call config();
   SET @US3_LAST_ERRNO = @OK;
@@ -209,8 +210,10 @@ BEGIN
 
   ELSE
     /* At this point we should have exactly 1 record */
-    SELECT personID, password, fname, lname, phone, email, userlevel, activated, authenticatePAM, userNamePAM
-    INTO   @US3_ID, l_password, @FNAME, @LNAME, @PHONE, @EMAIL, @USERLEVEL, activated, @authenticatePAM, @userNamePAM
+    SELECT personID, password, fname, lname, phone, email, userlevel,
+           activated, account_enabled, authenticatePAM, userNamePAM
+    INTO   @US3_ID, l_password, @FNAME, @LNAME, @PHONE, @EMAIL, @USERLEVEL,
+           l_activated, l_account_enabled, @authenticatePAM, @userNamePAM
     FROM   people
     WHERE  personGUID = p_personGUID;
 
@@ -265,18 +268,18 @@ BEGIN
 
       RETURN( @US3_LAST_ERRNO );
 
-    ELSEIF ( activated = false ) THEN
+    ELSEIF ( COALESCE(l_activated, 0) = 0 ) THEN
       SET @US3_LAST_ERRNO = @INACTIVE;
       IF ( @authenticatePAM != 1 ) THEN
          SET @US3_LAST_ERROR = CONCAT( 'MySQL: This account has not been activated yet. ',
                                        'Please activate your account first. ',
                                        'The activation code was sent to your e-mail address: ',
-                                        p_email);
+                                        @EMAIL);
       ELSE
          SET @US3_LAST_ERROR = CONCAT( 'MySQL: This account has not been activated yet. ',
                                        'Please contact your administrator' );
-      END IF;      
-        
+      END IF;
+
       SET @US3_ID     = NULL;
       SET @FNAME      = NULL;
       SET @LNAME      = NULL;
@@ -284,7 +287,22 @@ BEGIN
       SET @EMAIL      = NULL;
       SET @personGUID = NULL;
       SET @USERLEVEL  = NULL;
-  
+
+      RETURN( @US3_LAST_ERRNO );
+
+    ELSEIF ( COALESCE(l_account_enabled, 1) = 0 ) THEN
+      -- Administrator has disabled this account
+      SET @US3_LAST_ERRNO = @INACTIVE;
+      SET @US3_LAST_ERROR = 'MySQL: This account has been disabled. Please contact your administrator.';
+
+      SET @US3_ID     = NULL;
+      SET @FNAME      = NULL;
+      SET @LNAME      = NULL;
+      SET @PHONE      = NULL;
+      SET @EMAIL      = NULL;
+      SET @personGUID = NULL;
+      SET @USERLEVEL  = NULL;
+
       RETURN( @US3_LAST_ERRNO );
 
     ELSE
@@ -304,6 +322,7 @@ BEGIN
 END$$
 
 -- Checks the user with the passed email and password
+-- account_enabled = 0 blocks login even if activated = 1
 DROP FUNCTION IF EXISTS check_user_email$$
 CREATE FUNCTION check_user_email( p_email    VARCHAR(63),
                                   p_password VARCHAR(80) )
@@ -311,10 +330,11 @@ CREATE FUNCTION check_user_email( p_email    VARCHAR(63),
   READS SQL DATA
 
 BEGIN
-  DECLARE count_user INT;
-  DECLARE md5_pw     VARCHAR(80);
-  DECLARE l_password VARCHAR(80);
-  DECLARE activated  INT;
+  DECLARE count_user        INT;
+  DECLARE md5_pw            VARCHAR(80);
+  DECLARE l_password        VARCHAR(80);
+  DECLARE l_activated       INT;
+  DECLARE l_account_enabled INT;
 
   call config();
   SET @US3_LAST_ERRNO = @OK;
@@ -356,8 +376,10 @@ BEGIN
 
   ELSE
     -- At this point we should have exactly 1 record
-    SELECT personID, password, fname, lname, phone, personGUID, userlevel, activated, authenticatePAM, userNamePAM
-    INTO   @US3_ID, l_password, @FNAME, @LNAME, @PHONE, @personGUID, @USERLEVEL, activated, @authenticatePAM, @userNamePAM
+    SELECT personID, password, fname, lname, phone, personGUID, userlevel,
+           activated, account_enabled, authenticatePAM, userNamePAM
+    INTO   @US3_ID, l_password, @FNAME, @LNAME, @PHONE, @personGUID, @USERLEVEL,
+           l_activated, l_account_enabled, @authenticatePAM, @userNamePAM
     FROM   people
     WHERE  email = p_email;
 
@@ -411,7 +433,8 @@ BEGIN
       SET @USERLEVEL  = NULL;
 
       RETURN( @US3_LAST_ERRNO );
-    ELSEIF ( activated = false ) THEN
+
+    ELSEIF ( COALESCE(l_activated, 0) = 0 ) THEN
       SET @US3_LAST_ERRNO = @INACTIVE;
       IF ( @authenticatePAM != 1 ) THEN
          SET @US3_LAST_ERROR = CONCAT( 'MySQL: This account has not been activated yet. ',
@@ -419,9 +442,10 @@ BEGIN
                                        'The activation code was sent to your e-mail address: ',
                                         p_email);
       ELSE
-       SET @US3_LAST_ERROR = CONCAT( 'MySQL: This account has not been activated yet. ',
-                                         'Please contact your administrator' );
-      END IF;      
+         SET @US3_LAST_ERROR = CONCAT( 'MySQL: This account has not been activated yet. ',
+                                       'Please contact your administrator' );
+      END IF;
+
       SET @US3_ID     = NULL;
       SET @FNAME      = NULL;
       SET @LNAME      = NULL;
@@ -431,6 +455,22 @@ BEGIN
       SET @USERLEVEL  = NULL;
 
       RETURN( @US3_LAST_ERRNO );
+
+    ELSEIF ( COALESCE(l_account_enabled, 1) = 0 ) THEN
+      -- Administrator has disabled this account
+      SET @US3_LAST_ERRNO = @INACTIVE;
+      SET @US3_LAST_ERROR = 'MySQL: This account has been disabled. Please contact your administrator.';
+
+      SET @US3_ID     = NULL;
+      SET @FNAME      = NULL;
+      SET @LNAME      = NULL;
+      SET @PHONE      = NULL;
+      SET @EMAIL      = NULL;
+      SET @personGUID = NULL;
+      SET @USERLEVEL  = NULL;
+
+      RETURN( @US3_LAST_ERRNO );
+
     ELSE
       -- Successful login
       UPDATE people


### PR DESCRIPTION
This pull request introduces a new mechanism for disabling user accounts and auditing changes to user records. The main changes include adding an `account_enabled` flag to the `people` table, updating authentication procedures to check this flag, and creating a new `people_audit` table to track changes and actions related to user accounts.

**User account control:**

* Added a new `account_enabled` column to the `people` table, allowing administrators to disable accounts without deleting them. Disabled accounts cannot log in, even if they are activated.
* Updated the `check_user` and `check_user_email` authentication functions to check the `account_enabled` flag and deny login if it is set to 0, returning a clear error message. [[1]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L176-R177) [[2]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L212-R216) [[3]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L268-R277) [[4]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748R293-R307) [[5]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748R325) [[6]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L317-R337) [[7]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L359-R382) [[8]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L414-R437) [[9]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748R448-R463) [[10]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748R473)

**Auditing and compliance:**

* Added a new `people_audit` table to record changes and actions performed on user accounts, including account creation, updates, disables/enables, user level changes, and escalation rejections, along with relevant metadata and timestamps.

**Documentation and comments:**

* Added comments to clarify that `account_enabled = 0` blocks login, even if the account is activated. [[1]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748L164-R165) [[2]](diffhunk://#diff-9e1170c06beb3e536690c1e0b8cf92b8719d73503ca33fc432809abeecab3748R325)

These changes improve administrative control over user access and provide a robust audit trail for user account management activities.

**Testing:**
https://aucsolutions.atlassian.net/browse/UTM-146