### PR TITLE
[SQL change for ticket 825] -- do not block cretion of a new solution by trying to associate with experiment of ID==1

### DIFF
--- a/us3_solution_procs.sql
+++ b/us3_solution_procs.sql
@@ -361,22 +361,6 @@ BEGIN
         solutionID   = @LAST_INSERT_ID,
         personID     = p_ownerID;
 
-      -- -- Now associate solution with experiment, if we can
-      -- IF ( verify_experiment_permission( p_personGUID, p_password, p_experimentID ) = @OK ) THEN
-      --   INSERT INTO experimentSolutionChannel SET
-      --     experimentID = p_experimentID,
-      --     solutionID   = @LAST_INSERT_ID,
-      --     channelID    = p_channelID;
-
-      -- ELSE
-      --   -- just use the default experimentID
-      --   INSERT INTO experimentSolutionChannel SET
-      --     experimentID = 1,
-      --     solutionID   = @LAST_INSERT_ID,
-      --     channelID    = p_channelID;
-
-      -- END IF;
-
       -- Don't update @LAST_INSERT_ID, because the user is not interested in this one
 
     END IF;

--- a/us3_solution_procs.sql
+++ b/us3_solution_procs.sql
@@ -361,21 +361,21 @@ BEGIN
         solutionID   = @LAST_INSERT_ID,
         personID     = p_ownerID;
 
-      -- Now associate solution with experiment, if we can
-      IF ( verify_experiment_permission( p_personGUID, p_password, p_experimentID ) = @OK ) THEN
-        INSERT INTO experimentSolutionChannel SET
-          experimentID = p_experimentID,
-          solutionID   = @LAST_INSERT_ID,
-          channelID    = p_channelID;
+      -- -- Now associate solution with experiment, if we can
+      -- IF ( verify_experiment_permission( p_personGUID, p_password, p_experimentID ) = @OK ) THEN
+      --   INSERT INTO experimentSolutionChannel SET
+      --     experimentID = p_experimentID,
+      --     solutionID   = @LAST_INSERT_ID,
+      --     channelID    = p_channelID;
 
-      ELSE
-        -- just use the default experimentID
-        INSERT INTO experimentSolutionChannel SET
-          experimentID = 1,
-          solutionID   = @LAST_INSERT_ID,
-          channelID    = p_channelID;
+      -- ELSE
+      --   -- just use the default experimentID
+      --   INSERT INTO experimentSolutionChannel SET
+      --     experimentID = 1,
+      --     solutionID   = @LAST_INSERT_ID,
+      --     channelID    = p_channelID;
 
-      END IF;
+      -- END IF;
 
       -- Don't update @LAST_INSERT_ID, because the user is not interested in this one
 


### PR DESCRIPTION
Creation of a new solution (for new or existing DB) was blocked by a requirement (foreign key constraint) to associate it with the experiment having ID=1 - when such experiment record is absent; 

As a result, procedure "new_solution" failed silently, stopping at associating person with a solution, and returning @NO_SOLUTON error on the GUI side, precluding subsequent associations with the analyte and buffer.

The association with experiment is not needed for new solutions, as removed, and this solved the problem. 

Tested on demeler9 (where is failed previously): 
(1) created new solution
(2) used that solution in a test GMP run - solution was correctly coupled to the experiment at 3. IMPORT stage  